### PR TITLE
Fix curly braces deprecated error in User model

### DIFF
--- a/app/models/User.php
+++ b/app/models/User.php
@@ -74,7 +74,7 @@ class User extends ActiveRecord implements IdentityInterface
 	 */
 	public function getShortName()
 	{
-		return trim($this->first_name . ' ' . ($this->last_name ? $this->last_name{0} . '.' : ''));
+		return trim($this->first_name . ' ' . ($this->last_name ? $this->last_name[0] . '.' : ''));
 	}
 	
 	/**


### PR DESCRIPTION
Fixed curly braces deprecated error for compatibility with PHP 7.4. https://www.php.net/manual/en/migration74.deprecated.php